### PR TITLE
feat: 공통 레이아웃 및 페이지 라우팅 설정, 기본 페이지 구조 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.8.0",
         "styled-components": "^6.1.19",
         "web-vitals": "^2.1.4"
@@ -2041,6 +2042,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.8.0",
     "styled-components": "^6.1.19",
     "web-vitals": "^2.1.4"
   },
-    "scripts": {
+  "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,15 @@
 import './App.css';
 import { Outlet } from 'react-router-dom';
+import Header from './components/Header/Header';
+import BottomNav from './components/BottomNav/BottomNav';
+
 
 function App() {
   return (
     <div>
-      <h1>WETOWN 프로젝트</h1>
+      <Header />
       <Outlet />
+      <BottomNav />
     </div>
   );
 }

--- a/src/components/BottomNav/BottomNav.jsx
+++ b/src/components/BottomNav/BottomNav.jsx
@@ -1,0 +1,39 @@
+// src/components/BottomNav/BottomNav.jsx
+import * as S from "./styled";
+import { useNavigate } from "react-router-dom";
+import FloatingMapButton from "./FloatingMapButton";
+import { FaHome, FaPen, FaComments, FaNewspaper } from "react-icons/fa";
+
+const BottomNav = () => {
+    const navigate = useNavigate();
+
+    return (
+        <>
+            <S.NavWrapper>
+                <S.NavItem onClick={() => navigate("/")}>
+                    <FaHome size={20} />
+                    <span>홈</span>
+                </S.NavItem>
+                <S.NavItem onClick={() => navigate("/post")}>
+                    <FaPen size={20} />
+                    <span>제보</span>
+                </S.NavItem>
+
+                <div style={{ width: "64px" }} /> {/* 중앙 버튼 자리 확보 */}
+
+                <S.NavItem onClick={() => navigate("/board")}>
+                    <FaComments size={20} />
+                    <span>게시판</span>
+                </S.NavItem>
+                <S.NavItem onClick={() => navigate("/news")}>
+                    <FaNewspaper size={20} />
+                    <span>뉴스</span>
+                </S.NavItem>
+            </S.NavWrapper>
+
+            <FloatingMapButton />
+        </>
+    );
+};
+
+export default BottomNav;

--- a/src/components/BottomNav/FloatingMapButton.jsx
+++ b/src/components/BottomNav/FloatingMapButton.jsx
@@ -1,0 +1,15 @@
+import * as S from "./styled";
+import { useNavigate } from "react-router-dom";
+import { FaMapMarkedAlt } from "react-icons/fa";
+
+const FloatingMapButton = () => {
+    const navigate = useNavigate();
+
+    return (
+        <S.FloatingButton onClick={() => navigate("/map")}>
+            <FaMapMarkedAlt size={30} color="#fff" />
+        </S.FloatingButton>
+    );
+};
+
+export default FloatingMapButton;

--- a/src/components/BottomNav/styled.js
+++ b/src/components/BottomNav/styled.js
@@ -1,0 +1,60 @@
+import styled from "styled-components";
+
+// 하단바 wrapper
+export const NavWrapper = styled.nav`
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    height: 75px;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    z-index: 1000;
+    border-radius: 0 0 10px 10px;
+    background: var(--bg1, #FFF);
+    box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25) inset;
+`;
+
+// 하단 네비게이션 버튼
+export const NavItem = styled.button`
+    background: none;
+    border: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    gap: 4px;
+    color: var(--text, #000);
+    text-align: center;
+    font-family: Pretendard;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+
+    &:hover {
+        color: #000;
+        font-weight: 600;
+    }
+`;
+
+// 중앙 플로팅 지도 버튼
+export const FloatingButton = styled.button`
+    position: fixed;
+    bottom: 32px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 64px;
+    height: 64px;
+    background-color: #4f46e5;
+    border-radius: 50%;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 1100;
+    padding: 0;
+    cursor: pointer;
+`;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,0 +1,11 @@
+import * as S from "./styled";
+
+const Header = () => {
+    return (
+        <S.HeaderWrapper>
+            <S.Title>WE:TOWN</S.Title>
+        </S.HeaderWrapper>
+    );
+};
+
+export default Header;

--- a/src/components/Header/styled.js
+++ b/src/components/Header/styled.js
@@ -1,0 +1,36 @@
+// src/components/Header/styled.js
+import styled from "styled-components";
+
+export const HeaderWrapper = styled.header`
+    width: 100%;
+    height: 56px;
+    /* background-color: #ffffff; */
+    border-bottom: 1px solid #eaeaea;
+    border-radius: 0 0 10px 10px;
+    background: var(--main, #3851EC);
+    display: flex;
+    align-items: center;
+    /* justify-content: center; */
+    padding-left: 16px;
+    position: fixed;
+    top: 0;
+    z-index: 1000;
+    /* padding: 5% 30px 2% 7px; */
+
+    @media (min-width: 768px) {
+        height: 64px;
+    }
+`;
+
+export const Title = styled.h1`
+    color: var(--bg1, #FFF);
+    font-family: Pretendard;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+
+    @media (min-width: 768px) {
+        font-size: 20px;
+    }
+`;

--- a/src/pages/Board/BoardPage.jsx
+++ b/src/pages/Board/BoardPage.jsx
@@ -1,0 +1,5 @@
+const BoardPage = () => {
+    return <div style={{ marginTop: '70px' }}>게시판 페이지</div>;
+};
+
+export default BoardPage;

--- a/src/pages/Home/HomePage.jsx
+++ b/src/pages/Home/HomePage.jsx
@@ -1,0 +1,5 @@
+const HomePage = () => {
+    return <div style={{ marginTop: '70px' }}>홈 페이지</div>;
+};
+
+export default HomePage;

--- a/src/pages/Map/MapPage.jsx
+++ b/src/pages/Map/MapPage.jsx
@@ -1,0 +1,5 @@
+const MapPage = () => {
+    return <div style={{ marginTop: '70px' }}>지도 페이지</div>;
+};
+
+export default MapPage;

--- a/src/pages/News/NewsPage.jsx
+++ b/src/pages/News/NewsPage.jsx
@@ -1,0 +1,5 @@
+const NewsPage = () => {
+    return <div style={{ marginTop: '70px' }}>뉴스 페이지</div>;
+};
+
+export default NewsPage;

--- a/src/pages/Write/WritePage.jsx
+++ b/src/pages/Write/WritePage.jsx
@@ -1,0 +1,5 @@
+const WritePage = () => {
+    return <div style={{ marginTop: '70px' }}>글쓰기 페이지</div>;
+};
+
+export default WritePage;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -2,15 +2,26 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from './App';
 
+import HomePage from "./pages/Home/HomePage";
+import WritePage from "./pages/Write/WritePage";
+import MapPage from "./pages/Map/MapPage";
+import BoardPage from "./pages/Board/BoardPage";
+import NewsPage from "./pages/News/NewsPage";
+
+
 
 const router = createBrowserRouter([
     {
-        path: '/',
+        path: "/",
         element: <App />,
         children: [
-            
+            { path: "/", element: <HomePage /> },
+            { path: "/post", element: <WritePage /> },
+            { path: "/map", element: <MapPage /> },
+            { path: "/board", element: <BoardPage /> },
+            { path: "/news", element: <NewsPage /> },
         ],
-    },
+        },
 ]);
 
 export default router;


### PR DESCRIPTION
### ✨ 구현 내용
- App.jsx에 Header 및 BottomNav 공통 레이아웃 구성
- react-router-dom을 활용한 페이지 라우팅(router.jsx) 설정
- 아래 5개 페이지 추가 및 기본 JSX 구조 작성:
  - 홈(Home): `/`
  - 제보글 작성(Write): `/post`
  - 지도(Map): `/map`
  - 게시판(Board): `/board`
  - 뉴스(News): `/news`
- 모바일 웹뷰 기준으로 Header, BottomNav 스타일 적용
- 지도 페이지 이동용 FloatingMapButton 컴포넌트 구현



### 📌 향후 해야 할 작업
- 각 페이지별 실제 기능 구현
- BottomNav에서 현재 페이지에 해당하는 아이콘을 활성화 스타일로 변경 (선택된 상태 시 강조)


